### PR TITLE
ENT-4545: Wildcards for sub-sub domains for OC SSO-Notificatie

### DIFF
--- a/oc-sso-notificatie/src/test/java/nl/kennisnet/services/web/controller/UrlMatchWildCardsTest.java
+++ b/oc-sso-notificatie/src/test/java/nl/kennisnet/services/web/controller/UrlMatchWildCardsTest.java
@@ -48,6 +48,12 @@ class UrlMatchWildCardsTest {
     }
 
     @Test
+    void matchSecondSubDomainSingleWildcardTest() {
+        Assertions.assertTrue(SsoNotificationController.matchWildcards("http://subsub.subdomain.exampledomain.com",
+                "http://*.exampledomain.com"));
+    }
+
+    @Test
     void matchSecondSubDomainWildcardsFailTest() {
         Assertions.assertFalse(SsoNotificationController.matchWildcards("http://subdomein.exampledomain.com",
                 "http://*.subdomein.exampledomain.com"));

--- a/release/src/site/markdown/docs/2.0.6-SNAPSHOT/release-notes.md
+++ b/release/src/site/markdown/docs/2.0.6-SNAPSHOT/release-notes.md
@@ -11,9 +11,9 @@
 ## Changes
 <!-- Please note only the stories should be added. -->
 
-| #        | Description                                                   |
-|:---------|:--------------------------------------------------------------|
-| ENT-XXXX |                                                               |
+| #        | Description                                          |
+|:---------|:-----------------------------------------------------|
+| ENT-4545 | Wildcards for sub-sub domains for OC SSO-Notificatie |
 
 
 ## Configuration changes


### PR DESCRIPTION
Added unit tests that tests the functionality of a sub-sub-domain url with a whitelist containing only a single wildcard, e.g.: *.test.com